### PR TITLE
Move all client socket handling to child process.

### DIFF
--- a/worstPythonWebserverEver/server.py
+++ b/worstPythonWebserverEver/server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import socket
 
 def main():
     import config
@@ -8,9 +8,7 @@ def main():
     serversocket = createSocket(config)
     while True:
         (clientsocket, address) = serversocket.accept()
-        data = clientsocket.recv(1024)
-        p = mp.Process(target=handleRequest, args=(args, config,
-                                                   data, clientsocket))
+        p = mp.Process(target=handleRequest, args=(args, config, clientsocket))
         p.start()
         p.join()
     serversocket.close()
@@ -26,12 +24,15 @@ def createSocket(config):
     return serversocket
 
 
-def handleRequest(args, config, data, clientsocket):
+def handleRequest(args, config, clientsocket):
     import receive
     clientsocket.setblocking(0)
+    data = clientsocket.recv(1024)
     response = receive.main(args, config, data)
     clientsocket.send(response)
+    clientsocket.shutdown(socket.SHUT_RDWR)
     clientsocket.close()
+    del clientsocket
     return
 
 


### PR DESCRIPTION
The real problem was that clients weren't reliably getting a shutdown (close() is supposed to do this, but, at least on my machines it wasn't until another client connected).

I will say that this is generally how these things are written.  The main listener opens a client socket and then hands that entire socket off to something else to get processed.  The child then shuts the client socket down and the socket gets deleted.